### PR TITLE
fix: ensure correct action variable is used

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,41 @@
+name: 'preview'
+on: # rebuild any PRs and main branch changes
+  pull_request_target:
+    # use default types + closed event type
+    types: [opened, synchronize, reopened, closed]
+  push:
+    branches:
+      - main
+      - 'releases/*'
+      - test
+      - v1
+
+jobs:
+  preview: # make sure the action works on a clean machine without building
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        name: test afc163/surge-preview
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          build: |
+            npm install
+            npm run build
+          dist: public
+          teardown: 'true'
+  preview2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        name: test afc163/surge-preview
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          build: |
+            npm install
+            npm run build
+          dist: public
+          teardown: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,7 @@
 name: 'build-test'
 on: # rebuild any PRs and main branch changes
   pull_request_target:
-    # use default types + closed event type
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
@@ -19,31 +18,3 @@ jobs:
           npm install
       - run: |
           npm run all
-  preview: # make sure the action works on a clean machine without building
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./
-        name: test afc163/surge-preview
-        with:
-          surge_token: ${{ secrets.SURGE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          build: |
-            npm install
-            npm run build
-          dist: public
-          teardown: 'true'
-  preview2:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./
-        name: test afc163/surge-preview
-        with:
-          surge_token: ${{ secrets.SURGE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          build: |
-            npm install
-            npm run build
-          dist: public
-          teardown: 'true'

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ async function main() {
   let prNumber: number | undefined;
   core.debug('github.context');
   core.debug(JSON.stringify(github.context, null, 2));
-  const { job, payload, action } = github.context;
+  const { job, payload } = github.context;
   core.debug(`payload.after: ${payload.after}`);
   core.debug(`payload.after: ${payload.pull_request}`);
   const gitCommitSha = payload.after || payload?.pull_request?.head?.sha;
@@ -117,7 +117,7 @@ ${formatImage({
     ? `https://github.com/${github.context.repo.owner}/${github.context.repo.repo}/runs/${checkRunId}`
     : `https://github.com/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${github.context.runId}`;
 
-  if (teardown && action === 'closed') {
+  if (teardown && payload.action === 'closed') {
     try {
       core.info(`Teardown: ${url}`);
       core.setSecret(surgeToken);


### PR DESCRIPTION
closes #38 

based on the debug log i made a small mistake with where i was reading the variable

```bash
github.context
##[debug]{
##[debug]  "payload": {
##[debug]    "action": "closed",
##[debug]    "number": 37,
##[debug]    "pull_request": {
```