### PR TITLE
fix: correctly detect PR number when run with workflow_run

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,18 +38,25 @@ async function main() {
   const fromForkedRepo = payload.pull_request?.head.repo.fork;
 
   if (payload.number && payload.pull_request) {
+    core.debug('prNumber retrieved from pull_request');
     prNumber = payload.number;
   } else {
-    const result =
-      await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
-        owner: github.context.repo.owner,
-        repo: github.context.repo.repo,
-        commit_sha: gitCommitSha,
-      });
-    const pr = result.data.length > 0 && result.data[0];
-    core.debug('listPullRequestsAssociatedWithCommit');
-    core.debug(JSON.stringify(pr, null, 2));
-    prNumber = pr ? pr.number : undefined;
+    core.debug('Not a pull_request, so doing a API search');
+    // Inspired by https://github.com/orgs/community/discussions/25220#discussioncomment-8697399
+    const query = {
+      q: `repo:${github.context.repo.owner}/${github.context.repo.repo} is:pr sha:${gitCommitSha}`,
+      per_page: 1,
+    };
+    try {
+      const result = await octokit.rest.search.issuesAndPullRequests(query);
+      const pr = result.data.items.length > 0 && result.data.items[0];
+      core.debug(`Found related pull_request: ${JSON.stringify(pr, null, 2)}`);
+      prNumber = pr ? pr.number : undefined;
+    } catch (e) {
+      // As mentioned in https://github.com/orgs/community/discussions/25220#discussioncomment-8971083
+      // from time to time, you may get rate limit errors given search API seems to use many calls internally.
+      core.warning(`Unable to get the PR number with API search: ${e}`);
+    }
   }
   if (!prNumber) {
     core.info(`😢 No related PR found, skip it.`);


### PR DESCRIPTION
Update the call to the GitHub Rest API, as the previous one wasn't able to retrieve the Pull Request associated to the workflow_run.

From time to time, the API call may get rate limit errors given search API seems to use many calls internally. In this case, the error is caught and a warning is logged. Running the workflow again should then succeed.

Using workflow_run lets do surge deployment when the PR is created from a fork.

This makes this action directly usable instead of developing custom solutions like in  
ant-design/ant-design-pro@v6.0.0-beta.1/.github/workflows/preview-deploy.yml which recreate the whole action logic in the workflow definition.

Fixes https://github.com/afc163/surge-preview/issues/124
This fix was developed in collaboration with @benjaminparisel


### Notes

This change has been intensively tested through a custom implementation of the surge-preview action provided in https://github.com/benjaminParisel/surge-preview/pull/1 (same content as the PR proposed here).
This custom implementation has been tested in a PR created from a fork repo, see https://github.com/process-analytics/github-actions-playground/pull/349. It has also been tested with PR created from the target repository, see https://github.com/process-analytics/github-actions-playground/pull/350.

The implementation is adapted from https://github.com/orgs/community/discussions/25220#discussioncomment-8697399. The API rate limit was mentioned in https://github.com/orgs/community/discussions/25220#discussioncomment-8971083 and we have encountered once or twice during our tests. That's why we decided to handle the error and add a warning log in this case.

The dist folder has not been updated to include binary changes, and let the maintainers of this repo do the update by themself. If you need me to push the dist folder as well, please let me know.

If this PR is merged, we could later contribute to documentation improvements to describe the workflow_run usage to manage deployment for PR created from a fork repository. For example, explain:
  - how to build the site in a 1st workflow triggered by a pull_request event, and then deployed with a second
  - that teardown can be managed in a specific workflow like in https://github.com/process-analytics/github-actions-playground/pull/351
  - that the start deployment message can be initiated like in https://github.com/ant-design/ant-design-pro/blob/v6.0.0-beta.1/.github/workflows/preview-start.yml