### PR TITLE
fix: prevent lint-staged from failing on non-biome files

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "typescript": "^5.0.0"
   },
   "lint-staged": {
-    "*": "biome check --write"
+    "*": "biome check --write --files-ignore-unknown=true --no-errors-on-unmatched"
   }
 }


### PR DESCRIPTION
## Problem

The current lint-staged config runs biome against **every** staged file:

```json
"lint-staged": {
  "*": "biome check --write"
}
```

When a commit only touches files biome does not handle (e.g. a Markdown-only docs change), biome exits with `No files were processed` and the `pre-commit` hook **fails, blocking the commit**.

## Fix

Add the two flags biome recommends for lint-staged integration:

- `--files-ignore-unknown=true` — silently skip file types biome does not support
- `--no-errors-on-unmatched` — do not error when no files match

```json
"lint-staged": {
  "*": "biome check --write --files-ignore-unknown=true --no-errors-on-unmatched"
}
```

## Verification

Committing a Markdown-only change now passes the `pre-commit` hook cleanly (this PR's own commit went through the hook successfully). Running the command directly against `README.md` exits `0` instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)