### PR TITLE
docs: summarize new preview features and bump to 1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,22 @@ Compared to Netlify / Vercel:
 - 🆓 **It is free.**
 - 🧩 **It supports multiple preview jobs.**
 
+## 🎁 Features
+
+Every pull request gets a rich, self-updating preview comment. Beyond the live preview link, you can opt into:
+
+- 📱 **Mobile QR code** — scan the preview URL straight from the comment.
+- 🖼️ **Preview screenshot** — see the deployed page inline (via [thum.io](https://www.thum.io/)) with [`screenshot`](#-inputs).
+- 🔦 **Lighthouse scores** — performance / accessibility / best-practices / SEO, via [`lighthouse`](#-inputs).
+- 📦 **Artifact size report** — built `dist` size and file count, with a diff against the previous deployment.
+- 📋 **Failure log** — on a failed build/deploy, the tail of the log is shown in the comment so you don't have to dig through the Actions logs.
+- ✅ **Commit check run** — surface the deployment as a PR check with [`setCommitStatus`](#-inputs), useful for the `workflow_run` flow.
+
+All extras are off by default and add no new dependency.
+
 ## 📖 Table of Contents
 
+- [Features](#-features)
 - [Usage](#-usage)
   - [Multiple Jobs](#multiple-jobs)
   - [Teardown](#teardown)
@@ -307,6 +321,9 @@ However, when the workflow runs, the usual comment is updated by the `surge-prev
 | `setCommitStatus` | Publish the deployment as a commit check run so it shows up in the PR checks (requires `checks: write`). Especially useful for the `workflow_run` flow, where the deployment otherwise has no status on the commit. | `false`                                                                                            |
 | `screenshot`    | Embed a screenshot of the deployed preview in the PR comment (rendered via the [thum.io](https://www.thum.io/) service).           | `false`                                                                                                                                  |
 | `lighthouse`    | Run Lighthouse (via the [PageSpeed Insights](https://developers.google.com/speed/docs/insights/v5/get-started) API) against the deployed preview and post the scores in the PR comment. | `false`                                                              |
+
+> [!TIP]
+> The keyless PageSpeed Insights quota is small and shared across GitHub's runner IPs, so `lighthouse` may occasionally report no scores. Set a `PAGESPEED_API_KEY` (or `PSI_API_KEY`) [env var](https://docs.github.com/en/actions/learn-github-actions/variables) on the step to lift the limit — [get a key here](https://developers.google.com/speed/docs/insights/v5/get-started#APIKey).
 
 ## 📤 Outputs
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surge-preview",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "private": true,
   "description": "Preview website in surge.sh for every pull request",
   "main": "lib/main.js",

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -82,9 +82,13 @@ function setupPullRequestContext(fork = false) {
 async function runMain() {
   await jest.isolateModulesAsync(async () => {
     require('./main');
-    await flush();
-    await flush();
-    await flush();
+    // Flush enough microtask turns for the full async chain (build → deploy →
+    // measure → check run → comment → optional lighthouse) to settle, even on
+    // slower CI where too few turns left the later steps (e.g. the success
+    // check-run update) unfinished.
+    for (let i = 0; i < 15; i += 1) {
+      await flush();
+    }
   });
 }
 


### PR DESCRIPTION
Wraps up the batch of preview-comment features that just merged (#332 #333 #334 #335 #336).

- Adds a **Features** section to the README summarizing all six capabilities (QR code, screenshot, Lighthouse, size report, failure log, commit check run).
- Adds a tip on setting `PAGESPEED_API_KEY` to lift the keyless PageSpeed Insights quota for `lighthouse`.
- Bumps the version to **1.12.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)