### PR TITLE
chore(deps): bump grouped deps & switch dependabot to grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,37 @@
 version: 2
 updates:
-  # Enable version updates for npm
+  # Keep npm dependencies up to date, batched into grouped PRs
   - package-ecosystem: 'npm'
     # Look for `package.json` and `lock` files in the `root` directory
     directory: '/'
-    # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: 'daily'
-  - package-ecosystem: "github-actions"
+      interval: 'weekly'
+    # Combine updates into a few grouped PRs instead of one PR per package
+    groups:
+      production-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
+          - 'major'
+      development-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+          - 'major'
+
+  # Keep GitHub Actions up to date, batched into a single grouped PR
+  - package-ecosystem: 'github-actions'
     # Workflow files stored in the default location of `.github/workflows`
-    directory: "/"
+    directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+          - 'major'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,7 @@ jobs:
   preview: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./
         id: preview_step
         name: test afc163/surge-preview
@@ -38,7 +38,7 @@ jobs:
   preview2:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./
         id: preview_action
         name: test afc163/surge-preview

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: |
           npm install
       - run: |

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,7 @@
 {
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "files": {
-    "ignore": ["./dist/**/*", "./lib/**/*", "node_modules"]
+    "includes": ["**", "!dist/**/*", "!lib/**/*", "!**/node_modules"]
   },
   "formatter": {
     "enabled": true,
@@ -16,9 +17,11 @@
       "recommended": false,
       "complexity": {
         "noExtraBooleanCast": "error",
-        "noMultipleSpacesInRegularExpressionLiterals": "error",
         "noStaticOnlyClass": "error",
-        "noUselessConstructor": "error"
+        "noUselessConstructor": "error",
+        "noAdjacentSpacesInRegex": "error",
+        "noArguments": "error",
+        "noCommaOperator": "error"
       },
       "correctness": {
         "noConstAssign": "error",
@@ -28,7 +31,6 @@
         "noGlobalObjectCalls": "error",
         "noInnerDeclarations": "error",
         "noInvalidConstructorSuper": "error",
-        "noNewSymbol": "error",
         "noSelfAssign": "error",
         "noSwitchDeclarations": "error",
         "noUndeclaredVariables": "error",
@@ -38,15 +40,14 @@
         "noUnusedLabels": "error",
         "noUnusedVariables": "error",
         "useIsNan": "error",
-        "useYield": "error"
+        "useYield": "error",
+        "noInvalidBuiltinInstantiation": "error",
+        "useValidTypeof": "error"
       },
       "style": {
-        "noArguments": "error",
-        "noCommaOperator": "error",
         "noInferrableTypes": "error",
         "noNamespace": "error",
         "noNonNullAssertion": "warn",
-        "noVar": "error",
         "useConsistentArrayType": "error",
         "useConst": "error",
         "useForOf": "warn",
@@ -73,7 +74,7 @@
         "noMisleadingInstantiator": "error",
         "noRedeclare": "error",
         "noUnsafeNegation": "error",
-        "useValidTypeof": "error"
+        "noVar": "error"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,13 @@
     "type": "git",
     "url": "git+https://github.com/afc163/surge-preview.git"
   },
-  "keywords": ["actions", "surge", "preview", "pull-requests", "deploy"],
+  "keywords": [
+    "actions",
+    "surge",
+    "preview",
+    "pull-requests",
+    "deploy"
+  ],
   "author": "afc163 <afc163@gmail.com>",
   "license": "MIT",
   "dependencies": {
@@ -28,15 +34,15 @@
     "@actions/github": "^5.1.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.8.2",
-    "@types/jest": "^29.5.12",
-    "@types/node": "^20.14.8",
+    "@biomejs/biome": "^2.4.16",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^25.9.2",
     "@vercel/ncc": "^0.38.1",
     "husky": "^9.0.11",
-    "jest": "^29.7.0",
-    "jest-circus": "^29.7.0",
-    "lint-staged": "^15.2.7",
-    "ts-jest": "^29.1.5",
+    "jest": "^30.4.2",
+    "jest-circus": "^30.4.2",
+    "lint-staged": "^17.0.7",
+    "ts-jest": "^29.4.11",
     "typescript": "^5.0.0"
   },
   "lint-staged": {

--- a/src/lighthouse.test.ts
+++ b/src/lighthouse.test.ts
@@ -2,10 +2,10 @@ const warning = jest.fn();
 jest.mock('@actions/core', () => ({ warning }));
 
 import {
-  type LighthouseScores,
   fetchLighthouseScores,
   formatLighthouse,
   hasAnyScore,
+  type LighthouseScores,
   pageSpeedReportUrl,
 } from './lighthouse';
 


### PR DESCRIPTION
## 背景

图中 6 个 dependabot 更新 PR 因为大多是主版本跳跃而 CI 失败、长期堆积。本 PR 把它们一次性合并解决，并把 dependabot 改造成 **group 分组更新机制**，避免以后再出现“一个包一个 PR”的堆积。

## 一次性升级（替代那 6 个 PR）

| 依赖 | 旧版本 | 新版本 |
| --- | --- | --- |
| `actions/checkout` | 4 | 6 |
| `@biomejs/biome` | 1.9.4 | 2.4.16 |
| `jest` / `jest-circus` | 29.7.0 | 30.4.2 |
| `@types/jest` | 29.5.x | 30.0.0 |
| `lint-staged` | 15.5.x | 17.0.7 |
| `@types/node` | 20.x | 25.9.2 |

配套调整：
- `biome.json` 用 `biome migrate` 迁移到 v2 schema（`files.ignore` → `files.includes` 取反写法、规则归类调整），并补上 `$schema`。
- biome 2.x 默认启用 import 排序，`src/lighthouse.test.ts` 的 import 顺序随之调整。
- `ts-jest` 升到 29.4.11 以兼容 jest 30。
- 三个 workflow 里的 `actions/checkout@v4` → `@v6`。

> 注：`lint-staged@17` 要求 Node ≥ 22.22.1，CI 用的 `ubuntu-latest`（Node 24）满足；本地需 Node ≥ 22.22.1。

## dependabot 改造为 group 更新

- npm：拆成 `production-dependencies` 和 `development-dependencies` 两个分组，含 major/minor/patch，合成少量 PR。
- github-actions：`*` 全量分组成单个 PR。
- 频率从 `daily` 调成 `weekly`，进一步降噪。

## 验证

`npm run all` 全绿：tsc 构建 ✓、biome format/lint ✓、ncc 打包 ✓、**84 个测试全部通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)