### PR TITLE
docs: add GitHub Sponsors link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: afc163

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Marketplace][marketplace-image]][marketplace-url]
 [![Release][release-image]][release-url]
 [![License][license-image]][license-url]
+[![Sponsor][sponsor-image]][sponsor-url]
 
 [ci-image]: https://github.com/afc163/surge-preview/workflows/build-test/badge.svg
 [ci-url]: https://github.com/afc163/surge-preview/actions?query=workflow%3Abuild-test
@@ -17,6 +18,8 @@
 [release-url]: https://github.com/afc163/surge-preview/releases
 [license-image]: https://img.shields.io/github/license/afc163/surge-preview
 [license-url]: https://github.com/afc163/surge-preview/blob/main/LICENSE
+[sponsor-image]: https://img.shields.io/badge/sponsor-%E2%9D%A4-db61a2?logo=githubsponsors
+[sponsor-url]: https://github.com/sponsors/afc163
 
 English | [简体中文](./README.zh-CN.md)
 
@@ -388,3 +391,9 @@ However, when the workflow runs, the usual comment is updated by the `surge-prev
 
 - [jwalton/gh-find-current-pr](https://github.com/jwalton/gh-find-current-pr)
 - [marocchino/sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment)
+
+## ❤️ Sponsor
+
+If you find `surge-preview` useful, please consider sponsoring its development. Your support helps keep the project maintained and improved.
+
+- [Sponsor @afc163 on GitHub](https://github.com/sponsors/afc163)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,6 +8,7 @@
 [![Marketplace][marketplace-image]][marketplace-url]
 [![Release][release-image]][release-url]
 [![License][license-image]][license-url]
+[![Sponsor][sponsor-image]][sponsor-url]
 
 [ci-image]: https://github.com/afc163/surge-preview/workflows/build-test/badge.svg
 [ci-url]: https://github.com/afc163/surge-preview/actions?query=workflow%3Abuild-test
@@ -17,6 +18,8 @@
 [release-url]: https://github.com/afc163/surge-preview/releases
 [license-image]: https://img.shields.io/github/license/afc163/surge-preview
 [license-url]: https://github.com/afc163/surge-preview/blob/main/LICENSE
+[sponsor-image]: https://img.shields.io/badge/sponsor-%E2%9D%A4-db61a2?logo=githubsponsors
+[sponsor-url]: https://github.com/sponsors/afc163
 
 [English](./README.md) | 简体中文
 
@@ -388,3 +391,9 @@ jobs:
 
 - [jwalton/gh-find-current-pr](https://github.com/jwalton/gh-find-current-pr)
 - [marocchino/sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment)
+
+## ❤️ 赞助
+
+如果 `surge-preview` 对你有帮助，欢迎赞助它的开发。你的支持能帮助项目持续维护和改进。
+
+- [在 GitHub 上赞助 @afc163](https://github.com/sponsors/afc163)


### PR DESCRIPTION
## What

Add the [GitHub Sponsors](https://github.com/sponsors/afc163) link to the project:

- ❤️ **Sponsor badge** in both `README.md` and `README.zh-CN.md`
- ❤️ **Sponsor section** at the end of both READMEs
- ➕ **`.github/FUNDING.yml`** so the repo shows the Sponsor button

## Notes

The comment footer was intentionally left unchanged — the sponsor link lives only in the README and repo metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)